### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,11 +8,11 @@
   "customizations": {
       "vscode": {
       "extensions": [
-        "github.copilot",
-        "github.copilot-chat",
-        "vsls-contrib.codetour",
-        "ms-python.python",
-        "Phu1237.vs-browser"
+          "github.copilot",
+          "github.copilot-chat",
+          "markdown-lint.markdownlinter",
+          "ms-python.python", // Python extension
+          "ms-python.vscode-pylance" // Pylance extension for Python
       ]}
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,7 +8,7 @@
   "customizations": {
       "vscode": {
       "extensions": [
-          "github.copilot",
+          "github.copilot@insiders",
           "markdown-lint.markdownlinter",
           "ms-python.python", // Python extension
           "ms-python.vscode-pylance" // Pylance extension for Python

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,7 +9,6 @@
       "vscode": {
       "extensions": [
           "github.copilot",
-          "github.copilot-chat",
           "markdown-lint.markdownlinter",
           "ms-python.python", // Python extension
           "ms-python.vscode-pylance" // Pylance extension for Python


### PR DESCRIPTION
This pull request includes changes to the `.devcontainer/devcontainer.json` file, focusing on updating the list of extensions used in the development container.Update extensions in the vscode IDE for the devcontainer

Changes to the list of extensions:

* Removed `vsls-contrib.codetour` and `Phu1237.vs-browser` extensions.
* Added `markdown-lint.markdownlinter` and `ms-python.vscode-pylance` extensions.